### PR TITLE
Upstream two pecoff.c soundness fixes from rust-lang/rust

### DIFF
--- a/pecoff.c
+++ b/pecoff.c
@@ -604,7 +604,7 @@ coff_add (struct backtrace_state *state, int descriptor,
   int str_view_valid;
   size_t str_size;
   off_t str_off;
-  struct backtrace_view syms_view;
+  struct backtrace_view syms_view = {0};
   off_t syms_off;
   size_t syms_size;
   int syms_view_valid;

--- a/pecoff.c
+++ b/pecoff.c
@@ -602,7 +602,7 @@ coff_add (struct backtrace_state *state, int descriptor,
   const b_coff_section_header *sects;
   struct backtrace_view str_view;
   int str_view_valid;
-  size_t str_size;
+  uint32_t str_size;
   off_t str_off;
   struct backtrace_view syms_view = {0};
   off_t syms_off;


### PR DESCRIPTION
Hello! We've been using libbacktrace for quite some time in rust-lang/rust, and we've accumulated two small soundness fixes on the Windows side of things and figured it'd be good to send them upstream! Please let me know if anythings needs updating!