### PR TITLE
Avoid /proc on BSDs as it may not be mounted

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -76,6 +76,9 @@
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 
+/* Define to 1 if you have the <sys/sysctl.h> header file. */
+#undef HAVE_SYS_SYSCTL_H
+
 /* Define to 1 if you have the <sys/types.h> header file. */
 #undef HAVE_SYS_TYPES_H
 

--- a/configure
+++ b/configure
@@ -11731,6 +11731,20 @@ fi
 done
 
 
+# Check if BSDs can try KERN_PROC_PATHNAME
+for ac_header in sys/sysctl.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "sys/sysctl.h" "ac_cv_header_sys_sysctl_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_sysctl_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_SYSCTL_H 1
+_ACEOF
+
+fi
+
+done
+
+
 # Check for getexecname function.
 if test -n "${with_target_subdir}"; then
    case "${host}" in

--- a/configure.ac
+++ b/configure.ac
@@ -373,6 +373,9 @@ fi
 AC_CHECK_DECLS(strnlen)
 AC_CHECK_FUNCS(lstat readlink)
 
+# Check if BSDs can try KERN_PROC_PATHNAME
+AC_CHECK_HEADERS(sys/sysctl.h)
+
 # Check for getexecname function.
 if test -n "${with_target_subdir}"; then
    case "${host}" in

--- a/fileline.c
+++ b/fileline.c
@@ -39,8 +39,41 @@ POSSIBILITY OF SUCH DAMAGE.  */
 #include <stdlib.h>
 #include <unistd.h>
 
+#if defined(HAVE_SYS_SYSCTL_H)
+#include <sys/sysctl.h>
+#include <limits.h>
+#endif
+
 #include "backtrace.h"
 #include "internal.h"
+
+#if !defined(HAVE_GETEXECNAME) && defined(KERN_PROC_PATHNAME)
+/* Return pathname of executable or 0 on failure. */
+#define HAVE_GETEXECNAME
+static char execname[PATH_MAX + 1];
+static const char *
+getexecname (void)
+{
+  size_t path_len = sizeof(execname);
+  int mib[] = {
+    CTL_KERN,
+#if defined(__NetBSD__)
+    KERN_PROC_ARGS,
+    -1,
+    KERN_PROC_PATHNAME,
+#else
+    KERN_PROC,
+    KERN_PROC_PATHNAME,
+    -1,
+#endif
+  };
+
+  if (sysctl (mib, sizeof mib / sizeof mib[0], execname, &path_len, NULL, 0) < 0)
+    return NULL;
+
+  return execname;
+}
+#endif /* !HAVE_GETEXECNAME && KERN_PROC_PATHNAME */
 
 #ifndef HAVE_GETEXECNAME
 #define getexecname() NULL


### PR DESCRIPTION
Get path to executable via `KERN_PROC_PATHNAME` on BSDs, where /proc is not mounted by default. Let's implement `getexecname()` to avoid complicating
https://github.com/ianlancetaylor/libbacktrace/blob/5a99ff7fed66b8ea8f09c9805c138524a7035ece/fileline.c#L86-L114

Fixes rust-lang/rust#54434
These changes are in the public domain.