### PR TITLE
Don't filter out external Mach-O symbols

### DIFF
--- a/macho.c
+++ b/macho.c
@@ -474,8 +474,6 @@ macho_defined_symbol (uint8_t type)
 {
   if ((type & MACH_O_N_STAB) != 0)
     return 0;
-  if ((type & MACH_O_N_EXT) != 0)
-    return 0;
   switch (type & MACH_O_N_TYPE)
     {
     case MACH_O_N_ABS:


### PR DESCRIPTION
Undefined symbols have their N_TYPE set to N_UNDF
so they are already rejected by macho_defined_symbol.

See https://github.com/rust-lang/backtrace-rs/pull/299