### PR TITLE
Mark some test functions as __attribute__((optnone))

### DIFF
--- a/btest.c
+++ b/btest.c
@@ -48,7 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
 
 /* Test the backtrace function with non-inlined functions.  */
 
-static int test1 (void) __attribute__ ((noinline, noclone, unused));
+static int test1 (void) __attribute__ ((noinline, noclone, optnone, unused));
 static int f2 (int) __attribute__ ((noinline, noclone));
 static int f3 (int, int) __attribute__ ((noinline, noclone));
 
@@ -162,7 +162,7 @@ f13 (int f1line, int f2line)
 
 /* Test the backtrace_simple function with non-inlined functions.  */
 
-static int test3 (void) __attribute__ ((noinline, noclone, unused));
+static int test3 (void) __attribute__ ((noinline, noclone, optnone, unused));
 static int f22 (int) __attribute__ ((noinline, noclone));
 static int f23 (int, int) __attribute__ ((noinline, noclone));
 

--- a/edtest.c
+++ b/edtest.c
@@ -43,7 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
 
 #include "testlib.h"
 
-static int test1 (void) __attribute__ ((noinline, noclone, unused));
+static int test1 (void) __attribute__ ((noinline, noclone, optnone, unused));
 extern int f2 (int);
 extern int f3 (int, int);
 


### PR DESCRIPTION
On clang, disabling inlining is not enough to prevent some very simple
functions to be optimised out and replaced by a single jump instruction.

https://github.com/ianlancetaylor/libbacktrace/pull/34#issuecomment-596077925