### PR TITLE
Fix an off-by-one error in macho.c allocation

### DIFF
--- a/macho.c
+++ b/macho.c
@@ -871,7 +871,7 @@ macho_add_dsym (struct backtrace_state *state, const char *filename,
 	     + basenamelen
 	     + dsymsuffixdirlen
 	     + basenamelen
-	     + 1);
+	     + 2);
   dsym = backtrace_alloc (state, dsymlen, error_callback, data);
   if (dsym == NULL)
     goto fail;


### PR DESCRIPTION
This was narrowed down from a segfault first reported in https://github.com/rust-lang/backtrace-rs/issues/310, but it looks like the allocation here adds 1 for the trailing nul byte, but there's also a slash as part of the allocation so this ensures to add 2 instead of 1. Locally this fixes the segfault reported at https://github.com/rust-lang/backtrace-rs/issues/310