### PR TITLE
Use _Unwind_GetRegionStart() if _Unwind_GetIP() is not available

### DIFF
--- a/backtrace.c
+++ b/backtrace.c
@@ -82,6 +82,13 @@ unwind (struct _Unwind_Context *context, void *vdata)
       return _URC_NO_REASON;
     }
 
+  // Work around msys2 gcc buglet
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96948
+  if (pc == 0)
+    {
+      pc = _Unwind_GetRegionStart (context);
+    }
+
   if (!ip_before_insn)
     --pc;
 

--- a/simple.c
+++ b/simple.c
@@ -77,6 +77,13 @@ simple_unwind (struct _Unwind_Context *context, void *vdata)
       return _URC_NO_REASON;
     }
 
+  // Work around msys2 gcc buglet
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96948
+  if (pc == 0)
+    {
+      pc = _Unwind_GetRegionStart (context);
+    }
+
   if (!ip_before_insn)
     --pc;
 


### PR DESCRIPTION
Follow-up to #43. This gives correct function name, but still incorrect file+line information (and thus failing tests) on mingw64.