### PR TITLE
libbacktrace: correct buffer overflow tests

### DIFF
--- a/dwarf.c
+++ b/dwarf.c
@@ -1386,7 +1386,7 @@ resolve_string (const struct dwarf_sections *dwarf_sections, int is_dwarf64,
 
 	offset = val->u.uint * (is_dwarf64 ? 8 : 4) + str_offsets_base;
 	if (offset + (is_dwarf64 ? 8 : 4)
-	    >= dwarf_sections->size[DEBUG_STR_OFFSETS])
+	    > dwarf_sections->size[DEBUG_STR_OFFSETS])
 	  {
 	    error_callback (data, "DW_FORM_strx value out of range", 0);
 	    return 0;
@@ -1430,7 +1430,7 @@ resolve_addr_index (const struct dwarf_sections *dwarf_sections,
   struct dwarf_buf addr_buf;
 
   offset = addr_index * addrsize + addr_base;
-  if (offset + addrsize >= dwarf_sections->size[DEBUG_ADDR])
+  if (offset + addrsize > dwarf_sections->size[DEBUG_ADDR])
     {
       error_callback (data, "DW_FORM_addrx value out of range", 0);
       return 0;


### PR DESCRIPTION
            * dwarf.c (resolve_string): Use > rather than >= to check whether
            string index extends past buffer.
            (resolve_addr_index): Similarly for address index.

[This is a copy of commit 8f461a883ba from the main repo.]