### PR TITLE
docs: fix simple typo, aranges -> arranges

### DIFF
--- a/xcoff.c
+++ b/xcoff.c
@@ -130,7 +130,7 @@ typedef struct {
 
 #define SSUBTYP_DWINFO	0x10000	/* DWARF info section.  */
 #define SSUBTYP_DWLINE	0x20000	/* DWARF line-number section.  */
-#define SSUBTYP_DWARNGE	0x50000	/* DWARF aranges section.  */
+#define SSUBTYP_DWARNGE	0x50000	/* DWARF arranges section.  */
 #define SSUBTYP_DWABREV	0x60000	/* DWARF abbreviation section.  */
 #define SSUBTYP_DWSTR	0x70000	/* DWARF strings section.  */
 


### PR DESCRIPTION
There is a small typo in xcoff.c.

Should read `arranges` rather than `aranges`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md