### PR TITLE
Avoid extra output for objcopy test in configure

### DIFF
--- a/configure
+++ b/configure
@@ -12891,7 +12891,7 @@ else
   libbacktrace_cv_objcopy_debuglink=no
 elif ! test -n "${OBJCOPY}"; then
   libbacktrace_cv_objcopy_debuglink=no
-elif ${OBJCOPY} --add-gnu-debuglink=x /bin/ls /tmp/ls$$; then
+elif ${OBJCOPY} --add-gnu-debuglink=x /bin/ls /tmp/ls$$ 2> /dev/null; then
   rm -f /tmp/ls$$
   libbacktrace_cv_objcopy_debuglink=yes
 else

--- a/configure.ac
+++ b/configure.ac
@@ -496,7 +496,7 @@ AC_CACHE_CHECK([whether objcopy supports debuglink],
   libbacktrace_cv_objcopy_debuglink=no
 elif ! test -n "${OBJCOPY}"; then
   libbacktrace_cv_objcopy_debuglink=no
-elif ${OBJCOPY} --add-gnu-debuglink=x /bin/ls /tmp/ls$$; then
+elif ${OBJCOPY} --add-gnu-debuglink=x /bin/ls /tmp/ls$$ 2> /dev/null; then
   rm -f /tmp/ls$$
   libbacktrace_cv_objcopy_debuglink=yes
 else


### PR DESCRIPTION
On some platforms configure prints to stderr, but objcopy is successful:

    objcopy: /tmp/ls8710: debuglink section already exists