### PR TITLE
Add pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,9 @@ libbacktrace_la_LIBADD = \
 
 libbacktrace_la_DEPENDENCIES = $(libbacktrace_la_LIBADD)
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libbacktrace.pc
+
 # Testsuite.
 
 # Add a test to this variable if you want it to be built.

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 AC_PREREQ(2.69)
-AC_INIT(package-unused, version-unused,, libbacktrace)
+AC_INIT(libbacktrace, 1.0, https://github.com/ianlancetaylor/libbacktrace/issues,
+        libbacktrace, https://github.com/ianlancetaylor/libbacktrace)
 AC_CONFIG_SRCDIR(backtrace.h)
 AC_CONFIG_HEADER(config.h)
 AC_CONFIG_MACRO_DIR(config)

--- a/configure.ac
+++ b/configure.ac
@@ -538,7 +538,7 @@ else
   multilib_arg=
 fi
 
-AC_CONFIG_FILES(Makefile backtrace-supported.h)
+AC_CONFIG_FILES(Makefile backtrace-supported.h libbacktrace.pc)
 AC_CONFIG_FILES(install-debuginfo-for-buildid.sh, chmod +x install-debuginfo-for-buildid.sh)
 
 # We need multilib support, but only if configuring for the target.

--- a/libbacktrace.pc.in
+++ b/libbacktrace.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libbacktrace
+Description: A C library that may be linked into a C/C++ program to produce symbolic backtraces
+URL: https://github.com/ianlancetaylor/libbacktrace
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lbacktrace


### PR DESCRIPTION
* Provide project information to autotools
* Add pkg-config file

Resolves #65.

The generated `libbacktrace.pc` would look like this:
```
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: libbacktrace
Description: A C library that may be linked into a C/C++ program to produce symbolic backtraces
URL: https://github.com/ianlancetaylor/libbacktrace
Version: 1.0
Cflags: -I${includedir}
Libs: -L${libdir} -lbacktrace
```

Note that the autotools scripts need to be regenerated and I consider it would be better done by the project maintainers.