### PR TITLE
Improvement of PE stacktraces in case of ASLR

### DIFF
--- a/pecoff.c
+++ b/pecoff.c
@@ -1083,10 +1083,8 @@ static MODULE_INFORMATION_TABLE pe_create_module_info(struct backtrace_state *st
   phead_entry = &pldr_data->InMemoryOrderModuleList;
 
   // Count user modules : iterate through the entire list
-  pentry = phead_entry->Flink;
-  while (pentry != phead_entry) {
+  for(pentry = phead_entry->Flink; pentry != phead_entry; pentry = pentry->Flink) {
     count++;
-    pentry = pentry->Flink;
   }
 
   // Allocate the correct amount of memory depending of the modules count
@@ -1099,8 +1097,8 @@ static MODULE_INFORMATION_TABLE pe_create_module_info(struct backtrace_state *st
   module_information_table.ModuleCount = count;
 
   // Fill all the modules information in the table
-  pentry = phead_entry->Flink;
-  while (pentry != phead_entry) {
+  
+  for (pentry = phead_entry->Flink; pentry != phead_entry; pentry = pentry->Flink) {
     // Retrieve the current MODULE_ENTRY
     cur_module = &module_information_table.Modules[cur_count++];
 
@@ -1109,12 +1107,9 @@ static MODULE_INFORMATION_TABLE pe_create_module_info(struct backtrace_state *st
                                   InMemoryOrderModuleList);
 
     RtlCopyMemory(&cur_module->FullName, &pldr_entry->FullDllName,
-                  sizeof(cur_module->FullName));
+                  sizeof(cur_module->FullName)); // Copy of view, not the data
     RtlCopyMemory(&cur_module->BaseAddress, &pldr_entry->DllBase,
                   sizeof(cur_module->BaseAddress));
-
-    // Iterate to the next entry
-    pentry = pentry->Flink;
   }
 
   return module_information_table;
@@ -1185,6 +1180,7 @@ backtrace_initialize (struct backtrace_state *state,
     if(coff_fileline_fn_i != coff_nodebug)
       coff_fileline_fn = coff_fileline_fn_i;
   }
+  backtrace_free(state, moduleTable.Modules, moduleTable.ModuleCount * sizeof(MODULE_ENTRY) , error_callback, data);
 
   if (!ret)
     return 0;


### PR DESCRIPTION
fixes #103 

Instead of generating an empty stacktrace, libbacktrace generates now something like this:
```
   0# main at C:/Users/Febbe/workspace/test/test/main.cpp:7
   1# __tmainCRTStartup at C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:267
   2# mainCRTStartup at C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:188
   3# register_frame_ctor at :0
   4# register_frame_ctor at :0
   5#
```

To implement the resolution of addresses with ASLR, it is necessary to look into the Process Environment Block (PEB) of a process. It contains all the required information to map the pc to the functions. To read the PEB, functions from the Windows SDK are required. This is not possible via the POSIX API (:/). The functions defined by <link.h> would do this for POSIX and ELF, but this is not implemented for PE files in MSYS/Mingw/Cygwin environments. Most of the added code reads the PEB and returns the base addresses.

Somehow it was required to subtract the default [base-address](https://learn.microsoft.com/en-us/cpp/build/reference/base-base-address?view=msvc-170), which can be overridden by `/BASE` in the case ASLR is not used. The variable name of that address is `image-base` and it was already read from the PE/COFF.

I followed the implementation of the elf files. 
There, all dynamic libraries were loaded via the [dl_iterate_phdr](https://codebrowser.dev/glibc/glibc/elf/dl-iteratephdr.c.html#87) after the main executable file has been parsed. However, for PE on Windows this must be done also for the main file, since it also has a random base address.

Last but not least, there are still some issues with PE/COFF stacktraces: for libraries, no PE/COFF with dwarf has been generated, only the `register_frame_ctor` is shown. 
`#5` was in my case the start address 0xffffffffffffffff, so it probably should not be shown.