### PR TITLE
libbacktrace: Guess executable name using _pgmptr on windows

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -20,6 +20,10 @@
    don't. */
 #undef HAVE_DECL_STRNLEN
 
+/* Define to 1 if you have the declaration of `_pgmptr', and to 0 if you
+   don't. */
+#undef HAVE_DECL__PGMPTR
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 

--- a/configure
+++ b/configure
@@ -12517,6 +12517,19 @@ $as_echo "#define HAVE_GETEXECNAME 1" >>confdefs.h
 
 fi
 
+# Check for _pgmptr variable, contains the executable filename on windows
+ac_fn_c_check_decl "$LINENO" "_pgmptr" "ac_cv_have_decl__pgmptr" "$ac_includes_default"
+if test "x$ac_cv_have_decl__pgmptr" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL__PGMPTR $ac_have_decl
+_ACEOF
+
+
 # Check for sysctl definitions.
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for KERN_PROC" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -404,6 +404,9 @@ if test "$have_getexecname" = "yes"; then
   AC_DEFINE(HAVE_GETEXECNAME, 1, [Define if getexecname is available.])
 fi
 
+# Check for _pgmptr variable, contains the executable filename on windows
+AC_CHECK_DECLS([_pgmptr])
+
 # Check for sysctl definitions.
 
 AC_CACHE_CHECK([for KERN_PROC],

--- a/fileline.c
+++ b/fileline.c
@@ -155,6 +155,16 @@ macho_get_executable_path (struct backtrace_state *state,
 
 #endif /* !defined (HAVE_MACH_O_DYLD_H) */
 
+#if HAVE_DECL__PGMPTR
+
+#define windows_executable_filename() _pgmptr
+
+#else /* !HAVE_DECL__PGMPTR */
+
+#define windows_executable_filename() NULL
+
+#endif /* HAVE_DECL__PGMPTR */
+
 /* Initialize the fileline information from the executable.  Returns 1
    on success, 0 on failure.  */
 
@@ -192,7 +202,7 @@ fileline_initialize (struct backtrace_state *state,
 
   descriptor = -1;
   called_error_callback = 0;
-  for (pass = 0; pass < 8; ++pass)
+  for (pass = 0; pass < 9; ++pass)
     {
       int does_not_exist;
 
@@ -205,23 +215,30 @@ fileline_initialize (struct backtrace_state *state,
 	  filename = getexecname ();
 	  break;
 	case 2:
-	  filename = "/proc/self/exe";
+	  /*
+	   * Test this before /proc/self/exe, as the latter exists but points
+	   * to the wine binary (and thus doesn't work).
+	   */
+	  filename = windows_executable_filename ();
 	  break;
 	case 3:
-	  filename = "/proc/curproc/file";
+	  filename = "/proc/self/exe";
 	  break;
 	case 4:
+	  filename = "/proc/curproc/file";
+	  break;
+	case 5:
 	  snprintf (buf, sizeof (buf), "/proc/%ld/object/a.out",
 		    (long) getpid ());
 	  filename = buf;
 	  break;
-	case 5:
+	case 6:
 	  filename = sysctl_exec_name1 (state, error_callback, data);
 	  break;
-	case 6:
+	case 7:
 	  filename = sysctl_exec_name2 (state, error_callback, data);
 	  break;
-	case 7:
+	case 8:
 	  filename = macho_get_executable_path (state, error_callback, data);
 	  break;
 	default:


### PR DESCRIPTION
I had written a version using GetModuleFileNameA() when I noticed the reference to _pgmptr in its documentation. That's even easier. 

It's noisy to renumber the passes in fileline_initialize(), but without doing so, the windows code can't be tested with wine. On wine /proc/self/exe can be opened, but points to the wine binary.

See also #111 