### PR TITLE
Fix call to LIBTOOL with git bash

### DIFF
--- a/configure
+++ b/configure
@@ -7937,7 +7937,7 @@ fi
 LIBTOOL_DEPS="$ltmain"
 
 # Always use our own libtool.
-LIBTOOL='$(SHELL) $(top_builddir)/libtool'
+LIBTOOL='"$(SHELL)" $(top_builddir)/libtool'
 
 
 


### PR DESCRIPTION
Adding double-quotes around the `$(SHELL)` seems to make `$(SHELL)` expand correctly

Fixes #127 