### PR TITLE
Fix ATTRIBUTE_FALLTHROUGH for cross-compiler usage

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -56,12 +56,13 @@ POSSIBILITY OF SUCH DAMAGE.  */
 # endif
 #endif
 
-#ifndef ATTRIBUTE_FALLTHROUGH
-# if (GCC_VERSION >= 7000)
-#  define ATTRIBUTE_FALLTHROUGH __attribute__ ((__fallthrough__))
-# else
+#if defined(__has_attribute)
+#  if __has_attribute(fallthrough)
+#    define ATTRIBUTE_FALLTHROUGH __attribute__((fallthrough));
+#  endif
+#endif
+#if !defined(ATTRIBUTE_FALLTHROUGH)
 #  define ATTRIBUTE_FALLTHROUGH
-# endif
 #endif
 
 #ifndef HAVE_SYNC_FUNCTIONS


### PR DESCRIPTION
LLVM would also like fallthrough annotations.