### PR TITLE
Fix error and crash related to using inside a DLL

### DIFF
--- a/pecoff.c
+++ b/pecoff.c
@@ -1061,31 +1061,34 @@ backtrace_initialize (struct backtrace_state *state,
 #endif
 
 #ifdef HAVE_WINDOWS_H
-  nt_dll_handle = GetModuleHandleW (L"ntdll.dll");
-  if (nt_dll_handle)
+  if ((uintptr_t) GetModuleHandle (NULL) == module_handle)
     {
-      LDR_REGISTER_FUNCTION register_func;
-      const char register_name[] = "LdrRegisterDllNotification";
-      register_func = (void*) GetProcAddress (nt_dll_handle,
-					      register_name);
+    nt_dll_handle = GetModuleHandleW (L"ntdll.dll");
+    if (nt_dll_handle)
+        {
+        LDR_REGISTER_FUNCTION register_func;
+        const char register_name[] = "LdrRegisterDllNotification";
+        register_func = (void*) GetProcAddress (nt_dll_handle,
+                            register_name);
 
-      if (register_func)
-	{
-	  PVOID cookie;
-	  struct dll_notification_context *context
-	    = backtrace_alloc (state,
-			       sizeof (struct dll_notification_context),
-			       error_callback, data);
+        if (register_func)
+        {
+        PVOID cookie;
+        struct dll_notification_context *context
+            = backtrace_alloc (state,
+                    sizeof (struct dll_notification_context),
+                    error_callback, data);
 
-	  if (context)
-	    {
-	      context->state = state;
-	      context->data = data;
-	      context->error_callback = error_callback;
+        if (context)
+            {
+            context->state = state;
+            context->data = data;
+            context->error_callback = error_callback;
 
-	      register_func (0, &dll_notification, context, &cookie);
-	    }
-	}
+            register_func (0, &dll_notification, context, &cookie);
+            }
+        }
+        }
     }
 #endif /* defined(HAVE_WINDOWS_H) */
 

--- a/pecoff.c
+++ b/pecoff.c
@@ -1013,7 +1013,7 @@ backtrace_initialize (struct backtrace_state *state,
 #ifdef HAVE_WINDOWS_H
   HMODULE nt_dll_handle;
 
-  module_handle = (uintptr_t) GetModuleHandle (NULL);
+  module_handle = (uintptr_t) GetModuleHandle (state->filename);
 #endif
 
   ret = coff_add (state, descriptor, error_callback, data,


### PR DESCRIPTION
This fixes 2 issues I was having when using libbacktrace inside a Window DLL.

- Instead of GetModuleHandle (NULL), pass in the filename so we get the correct base address regardless of if we're running in a EXE or DLL. Before this patch, all debug symbol lookups within a 'main' DLL were offset by the base address of the parent process - giving nonsense.
- Only register for DLL added notifications if we are an EXE. We can't support this from inside a DLL without having a way to unregister the notification prior to our running DLL being unloaded. Before this fix we would get crashes related to calling registered functions that are no longer loaded.