### PR TITLE
libbacktrace: add bigobj COFF to filetype.awk

### DIFF
--- a/filetype.awk
+++ b/filetype.awk
@@ -3,6 +3,7 @@
 /^\177ELF\002/      { if (NR == 1) { print "elf64"; exit } }
 /^\114\001/         { if (NR == 1) { print "pecoff"; exit } }
 /^\144\206/         { if (NR == 1) { print "pecoff"; exit } }
+/^\000\000\377\377/ { if (NR == 1) { print "pecoff"; exit } }
 /^\001\337/         { if (NR == 1) { print "xcoff32"; exit } }
 /^\001\367/         { if (NR == 1) { print "xcoff64"; exit } }
 /^\376\355\372\316/ { if (NR == 1) { print "macho"; exit } }


### PR DESCRIPTION
The bigobj format (/bigobj, -mbig-obj) has different magic than normal COFF, but should still be detected as "pecoff".