### PR TITLE
Use correct type for backtrace_atomic_store_int in atomic.c

### DIFF
--- a/atomic.c
+++ b/atomic.c
@@ -103,7 +103,7 @@ backtrace_atomic_store_size_t (size_t *p, size_t v)
 void
 backtrace_atomic_store_int (int *p, int v)
 {
-  size_t old;
+  int old;
 
   old = *p;
   while (!__sync_bool_compare_and_swap (p, old, v))


### PR DESCRIPTION
libbacktrace: Use correct type in backtrace_atomic_store_int
    
libbacktrace:
    
        * atomic.c (backtrace_atomic_store_int): Use int for old value.
