### PR TITLE
libbacktrace: Fix missing table assignment in RLE seq decode

### DIFF
--- a/elf.c
+++ b/elf.c
@@ -4302,6 +4302,7 @@ elf_zstd_unpack_seq_decode (int mode,
 	decode->table_bits = 0;
 	if (!conv (&entry, 0, table))
 	  return 0;
+	decode->table = table;
       }
       break;
 

--- a/zstdtest.c
+++ b/zstdtest.c
@@ -125,6 +125,24 @@ static const struct zstd_test tests[] =
     27,
   },
   {
+    "rle-sequence-tables",
+    "AAAA",
+    0,
+    ("\x28\xb5\x2f\xfd"
+     "\x20" /* Single_Segment_flag; Frame_Content_Size_flag = 0 */
+     "\x04" /* Frame_Content_Size */
+     "\x45\x00\x00" /* Last_Block, Compressed_Block, size 8 */
+     "\x08" /* Raw_Literals_Block, Regenerated_Size 1 */
+     "A"
+     "\x01" /* Number_of_Sequences */
+     "\x54" /* RLE literals length, offset, and match length tables */
+     "\x01" /* literal length code: 1 */
+     "\x00" /* offset code: repeat offset 1 */
+     "\x00" /* match length code: 3 */
+     "\x80"), /* bitstream end marker */
+    17,
+  },
+  {
     "ranges",
     ("\xcc\x11\x00\x00\x00\x00\x00\x00\xd5\x13\x00\x00\x00\x00\x00\x00"
      "\x1c\x14\x00\x00\x00\x00\x00\x00\x72\x14\x00\x00\x00\x00\x00\x00"


### PR DESCRIPTION
Fixes segfault when decompressing mesa debuginfo on Aeryn. I added the test higher up so it merges cleanly with #165.