### PR TITLE
Use module handle as the base address for COFF syminfo

### DIFF
--- a/pecoff.c
+++ b/pecoff.c
@@ -677,8 +677,11 @@ coff_add (struct backtrace_state *state, int descriptor,
   int debug_view_valid;
   int is_64;
   struct libbacktrace_base_address image_base;
+  struct libbacktrace_base_address module_base;
   struct libbacktrace_base_address base_address;
   struct dwarf_sections dwarf_sections;
+
+  module_base.m = module_handle;
 
   *found_sym = 0;
   *found_dwarf = 0;
@@ -854,7 +857,7 @@ coff_add (struct backtrace_state *state, int descriptor,
       if (sdata == NULL)
 	goto fail;
 
-      if (!coff_initialize_syminfo (state, image_base, is_64,
+      if (!coff_initialize_syminfo (state, module_base, is_64,
 				    sects, sects_num,
 				    syms_view.data, syms_size,
 				    str_view.data, str_size,


### PR DESCRIPTION
This fix was originally mentioned in changes of #110, but the committed patches didn't include it:   https://github.com/ianlancetaylor/libbacktrace/pull/110/changes#diff-0daea205c8a4abccea5b76b0de83cf99b46ef8bfbc1cd98be593d28708788c36L789-R899

This makes `backtrace_syminfo` return correct results even when ASLR is enabled.